### PR TITLE
Support Python>=3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.9", "3.11"]
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install local packages
       run: |
-        pip install .[test]
+        pip install --upgrade pip setuptools && pip install .[test]
 
     - name: Unit tests
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ hashFiles('setup.py') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
         restore-keys: |
-          ${{ runner.os }}-
+          ${{ runner.os }}-${{ matrix.python-version }}-
 
     - name: Cache / restore SBML test suite
       id: cache-sbml-test-suite

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Main functionality:
 
 **NOTE: This is under development and the API is to be considered unstable**
 
+Python support policy: sbmlmath follows [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).
+
 ## Usage
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "SBML Math <-> SymPy"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 dependencies = [
     "python-libsbml",
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pre-commit"]
+test = ["pytest>=7", "pre-commit>=3"]
 
 [tool.black]
 line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "python-libsbml",
     "sympy",
     "pint",
-    "lxml",
+    "lxml>=4.6.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
* state python support policy
* change to python>=3.9
* also run tests with python3.9
* narrow down requirements to aid pip's dependency resolver

#1 