### PR TITLE
Add `set_math`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 dependencies = [
-    "python-libsbml",
+    "python-libsbml>=5.20.4",
     "sympy",
     "pint",
     "lxml>=4.6.4",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,6 +4,24 @@ import sympy as sp
 from sbmlmath import *
 
 
+def test_set_math():
+    """Test setting math on SBML objects."""
+    # create some model
+    doc = libsbml.SBMLDocument(3, 1)
+    model = doc.createModel()
+    s = model.createSpecies()
+    s.setId("s")
+    p = model.createParameter()
+    p.setId("p")
+    ia = model.createInitialAssignment()
+    ia.setSymbol("s")
+
+    # actual test
+    expr = sp.sympify("2 * p^2")
+    set_math(ia, expr)
+    assert expr == sbml_math_to_sympy(ia)
+
+
 def test_large_mathml():
     """
     lxml.etree.iterparse simply truncates long input (>2**15 chars);


### PR DESCRIPTION
Add `set_math(element: libsbml.SBase, expr: sp.Expr)` for updating a math element of an SBML entity.

Closes #24.

Also require `python-libsbml>=5.20.4`. At least with 5.20.0, the test fails due to duplicated `xmlns:sbml` attributes.